### PR TITLE
add `region_name` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ SessionManager(
     sid_byte_length=128,
     table_name='my-dynamodb-table',
     endpoint_url='http://localhost:8000',
+    region_name='us-east-1',
     idle_timeout_seconds=300,
     absolute_timeout_seconds=3600,
 )
@@ -171,6 +172,10 @@ instance.absolute_timeout_seconds = 30
 * Docker
 
 ### Tests
+
+[install `poetry`](https://python-poetry.org), then run `poetry install` to install the dependencies.
+
+To run tests, run `poetry run pytest`
 
 The integration tests will use the `docker-compose.yml` file to create a local DynamoDB instance.
 

--- a/dynamodb_session_web/_session.py
+++ b/dynamodb_session_web/_session.py
@@ -131,6 +131,7 @@ class SessionManager(Generic[T]):  # pylint: disable=too-many-instance-attribute
         self.sid_byte_length = kwargs.get('sid_byte_length', DEFAULT_SESSION_ID_BYTES)
         self.table_name = kwargs.get('table_name', DEFAULT_TABLE)
         self.endpoint_url = kwargs.get('endpoint_url', None)
+        self.region_name = kwargs.get('region_name', None)
         self._idle_timeout = kwargs.get('idle_timeout', DEFAULT_IDLE_TIMEOUT)
         self._absolute_timeout = kwargs.get('absolute_timeout', DEFAULT_ABSOLUTE_TIMEOUT)
         self._sid_keys = kwargs.get('sid_keys', [])
@@ -142,6 +143,7 @@ class SessionManager(Generic[T]):  # pylint: disable=too-many-instance-attribute
         self.sid_byte_length = kwargs.get('sid_byte_length', DEFAULT_SESSION_ID_BYTES)
         self.table_name = kwargs.get('table_name', DEFAULT_TABLE)
         self.endpoint_url = kwargs.get('endpoint_url', None)
+        self.region_name = kwargs.get('region_name', None)
         self._idle_timeout = kwargs.get('idle_timeout', DEFAULT_IDLE_TIMEOUT)
         self._absolute_timeout = kwargs.get('absolute_timeout', DEFAULT_ABSOLUTE_TIMEOUT)
         self._sid_keys = kwargs.get('sid_keys', [])
@@ -156,12 +158,14 @@ class SessionManager(Generic[T]):  # pylint: disable=too-many-instance-attribute
             sid_byte_length - The session id length in bytes. Defaults to 32.
             table_name - The DynamoDB table name. Defaults to app_session.
             endpoint_url - The DynamoDB URL. Defaults to None.
+            region_name - The DynamoDB Region. Defaults to None.
             idle_timeout - The timeout used to expire idle sessions. Defaults to 7200 seconds.
             absolute_timeout - The timeout used for absolute session expiration. Defaults to 43200 seconds.
         """
         self.sid_byte_length = kwargs.get('sid_byte_length', DEFAULT_SESSION_ID_BYTES)
         self.table_name = kwargs.get('table_name', DEFAULT_TABLE)
         self.endpoint_url = kwargs.get('endpoint_url', None)
+        self.region_name = kwargs.get('region_name', None)
         self._idle_timeout = kwargs.get('idle_timeout_seconds', DEFAULT_IDLE_TIMEOUT)
         self._absolute_timeout = kwargs.get('absolute_timeout_seconds', DEFAULT_ABSOLUTE_TIMEOUT)
         self._sid_keys = kwargs.get('sid_keys', [])
@@ -309,6 +313,10 @@ class SessionManager(Generic[T]):  # pylint: disable=too-many-instance-attribute
 
     def boto_client(self):
         if self._boto_client is None:
-            self._boto_client = boto3.client('dynamodb', endpoint_url=self.endpoint_url)
-
+            boto_client_kwargs = {}
+            if self.endpoint_url is not None:
+                boto_client_kwargs["endpoint_url"] = self.endpoint_url
+            if self.region_name is not None:
+                boto_client_kwargs["region_name"] = self.region_name
+            self._boto_client = boto3.client('dynamodb', **boto_client_kwargs)
         return self._boto_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynamodb-session-web"
-version = "0.2.7"
+version = "0.2.8"
 description = "Contains the core API for a DynamoDB-backed session"
 keywords = ["DynamoDB", "Session", "Web"]
 authors = ["Jason Capriotti <jason.capriotti@gmail.com>"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -43,6 +43,7 @@ class TestSessionCore:
         assert actual.sid_byte_length == 32
         assert actual.table_name == 'app_session'
         assert actual.endpoint_url is None
+        assert actual.region_name is None
 
     def test_create(self):
         # Base64 of each byte is approximately 1.3 characters
@@ -61,6 +62,7 @@ class TestSessionCore:
         expected_sid_byte_length = 1
         expected_table_name = 'some name'
         expected_dynamodb_endpoint_url = 'some URL'
+        expected_dynamodb_region_name = 'us-east-1'
         expected_idle_timeout = 4
         expected_absolute_timeout = 5
 
@@ -69,6 +71,7 @@ class TestSessionCore:
             sid_byte_length=expected_sid_byte_length,
             table_name=expected_table_name,
             endpoint_url=expected_dynamodb_endpoint_url,
+            region_name=expected_dynamodb_region_name,
             idle_timeout_seconds=expected_idle_timeout,
             absolute_timeout_seconds=expected_absolute_timeout
         )
@@ -76,6 +79,7 @@ class TestSessionCore:
         assert actual.sid_byte_length == expected_sid_byte_length
         assert actual.table_name == expected_table_name
         assert actual.endpoint_url == expected_dynamodb_endpoint_url
+        assert actual.region_name == expected_dynamodb_region_name
         assert actual._idle_timeout == expected_idle_timeout  # pylint: disable=protected-access
         assert actual._absolute_timeout == expected_absolute_timeout  # pylint: disable=protected-access
         assert isinstance(actual.create(), SessionDictInstance)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from pytest import param
 
 from dynamodb_session_web import NullSessionInstance, SessionManager, SessionInstanceBase
 from dynamodb_session_web.exceptions import InvalidSessionIdError, SessionNotFoundError
-from .utility import create_session_manager, get_dynamo_record, LOCAL_ENDPOINT, mock_current_datetime, str_param
+from .utility import create_session_manager, get_dynamo_record, LOCAL_ENDPOINT, LOCAL_REGION_NAME, mock_current_datetime, str_param
 
 DEFAULT_IDLE_TIMEOUT = 7200  # two hours
 DEFAULT_ABSOLUTE_TIMEOUT = 43200  # twelve hours
@@ -95,7 +95,7 @@ class TestIntegration:
             def serialize(self):
                 return json.dumps(asdict(self))
 
-        session = SessionManager(MySession, endpoint_url=LOCAL_ENDPOINT)
+        session = SessionManager(MySession, endpoint_url=LOCAL_ENDPOINT, region_name=LOCAL_REGION_NAME)
         initial_data = session.create()
         initial_data.fruit = 'apple'
         initial_data.color = 'red'

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -7,17 +7,18 @@ from dynamodb_session_web import SessionManager, SessionDictInstance
 
 TABLE_NAME = 'app_session'
 LOCAL_ENDPOINT = 'http://localhost:8000'
+LOCAL_REGION_NAME = 'us-east-1'
 
 
 def create_session_manager(**kwargs) -> SessionManager[SessionDictInstance]:
     """
     Creates a SessionCore object configured for integration testing
     """
-    return SessionManager(SessionDictInstance, endpoint_url=LOCAL_ENDPOINT, **kwargs)
+    return SessionManager(SessionDictInstance, endpoint_url=LOCAL_ENDPOINT, region_name=LOCAL_REGION_NAME, **kwargs)
 
 
 def get_dynamo_resource():
-    return boto3.resource('dynamodb', endpoint_url=LOCAL_ENDPOINT)
+    return boto3.resource('dynamodb', endpoint_url=LOCAL_ENDPOINT, region_name=LOCAL_REGION_NAME)
 
 
 def get_dynamo_record(key):


### PR DESCRIPTION
When running `dynamodb-session-flask`, if I connect to a local dynamodb instance, I get errors because the `region_name` is not specified, and must set the default region via env var, ie:

```bash
$ AWS_DEFAULT_REGION=us-east-1 flask run --host=0.0.0.0 --port 8080
```

PR adds `region_name` parameter to `SessionManager` so it can be used in `dynamodb-session-flask`